### PR TITLE
Document test webhook and implement endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# test_bot
+# WhiteBit Trading Bot
+
+A simple trading bot that integrates with WhiteBit and Telegram.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Create a `.env` file with your Telegram and WhiteBit credentials.
+3. Start the bot:
+   ```bash
+   npm start
+   ```
+
+## Testing Webhook Integration
+
+The bot includes a `/test-webhook` route to verify that webhook calls are correctly received.
+See [docs/test-webhook.md](docs/test-webhook.md) for details on how to send a sample payload and check the confirmation message.

--- a/bot.js
+++ b/bot.js
@@ -164,6 +164,23 @@ app.post('/webhook', async (req, res) => {
   }
 });
 
+app.post('/test-webhook', async (req, res) => {
+  if (req.headers['x-secret'] !== CONFIG.WEBHOOK_SECRET) {
+    res.status(403).send('Forbidden');
+    return;
+  }
+
+  const message = req.body && req.body.message ? req.body.message : 'ping';
+
+  try {
+    await tradingEngine.sendTelegramMessage(`✅ Получен тестовый webhook: ${message}`);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    logger.errorWithStack('Ошибка обработки test-webhook', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });

--- a/docs/test-webhook.md
+++ b/docs/test-webhook.md
@@ -1,0 +1,30 @@
+# Testing the Webhook Endpoint
+
+This project exposes a `/test-webhook` endpoint for verifying that the bot can receive webhook events and send a confirmation message to Telegram.
+
+## Sending a Request
+
+Use `curl` or a similar tool to POST a JSON payload. Include your `X-Secret` header that matches `WEBHOOK_SECRET` from your environment variables.
+
+```bash
+curl -X POST http://localhost:3000/test-webhook \
+  -H 'Content-Type: application/json' \
+  -H 'X-Secret: <WEBHOOK_SECRET>' \
+  -d '{"message":"ping"}'
+```
+
+## Expected Bot Response
+
+The HTTP response will be:
+
+```json
+{"status":"ok"}
+```
+
+Shortly after, the bot sends a Telegram message to the configured chat:
+
+```
+✅ Получен тестовый webhook: ping
+```
+
+Replace `ping` in the payload with any text to customize the confirmation message.


### PR DESCRIPTION
## Summary
- add README info and webhook testing docs
- implement `/test-webhook` endpoint to send confirmation to Telegram

## Testing
- `npm test` *(fails: Cannot find module 'test.js')*

------
https://chatgpt.com/codex/tasks/task_e_6845ee337db4832291e63a5cdea4a2ec